### PR TITLE
英文法学習アプリをZIPからGitHub Pagesへ公開

### DIFF
--- a/.github/workflows/english-grammar-pages.yml
+++ b/.github/workflows/english-grammar-pages.yml
@@ -1,0 +1,48 @@
+name: Deploy English Grammar App
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - deploy/english-grammar-app.zip
+      - .github/workflows/english-grammar-pages.yml
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: english-grammar-pages
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Extract and verify app
+        shell: bash
+        run: |
+          test -f deploy/english-grammar-app.zip
+          rm -rf site /tmp/english-grammar-app
+          mkdir -p site /tmp/english-grammar-app
+          unzip -q deploy/english-grammar-app.zip -d /tmp/english-grammar-app
+          APP_DIR="$(find /tmp/english-grammar-app -maxdepth 3 -type f -name index.html -printf '%h\n' | head -n 1)"
+          test -n "$APP_DIR"
+          cp -a "$APP_DIR"/. site/
+          test -f site/index.html
+          test -f site/app.js
+          test -f site/questions.js
+          test -f site/manifest.webmanifest
+      - uses: actions/configure-pages@v5
+      - uses: actions/upload-pages-artifact@v3
+        with:
+          path: site
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/deploy/UPLOAD_ENGLISH_GRAMMAR_APP.md
+++ b/deploy/UPLOAD_ENGLISH_GRAMMAR_APP.md
@@ -1,0 +1,23 @@
+# 英文法学習アプリ公開用
+
+このフォルダへ、完成版ZIPを次のファイル名で配置します。
+
+`english-grammar-app.zip`
+
+ZIPは展開せず、そのままアップロードします。
+
+mainブランチへ反映されると、GitHub ActionsがZIP内の`index.html`を探して展開し、GitHub Pagesへ公開します。
+
+公開対象ZIPの内容：
+
+- index.html
+- styles.css
+- app.js
+- questions.js
+- manifest.webmanifest
+- sw.js
+- icon.svg
+- icon-192.svg
+- icon-512.svg
+
+既存のAstroサイトのビルドや公開設定には影響しません。


### PR DESCRIPTION
## 変更内容

- 完成版アプリZIPを自動展開するGitHub Pagesワークフローを追加
- 公開前に `index.html`、`app.js`、`questions.js`、`manifest.webmanifest` の存在を検証
- 既存のAstro／Netlifyサイトのビルド構成には変更を加えない

## 公開手順

1. `英文法学習アプリ_完成版_v1.zip` をダウンロード
2. このブランチの `deploy` フォルダへ、`english-grammar-app.zip` という名前でZIPのままアップロード
3. 検証後にPRをマージ
4. GitHub ActionsがGitHub Pagesへ自動公開

## 検証済みアプリ内容

- 全2,280問
- 28単元・112小分類
- 問題ID重複0件
- 完全同一問題0件
- JavaScript構文エラー0件
